### PR TITLE
detect when headset does not send valid tracking data and pause

### DIFF
--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -404,6 +404,16 @@ void CalibrationTick(double time)
 		}
 	});
 
+	// check for non-updating headset tracking space (caused by quest out of bounds or taken off head for example) and abort everything for this tick
+	auto p = ctx.devicePoses[vr::k_unTrackedDeviceIndex_Hmd].vecPosition;
+	if ((p[0] == 0.0 && p[1] == 0.0 && p[2] == 0.0) || (ctx.xprev == p[0] && ctx.yprev == p[1] && ctx.zprev == p[2])) {
+		// std::cerr << "HMD tracking didn't update, skipping update" << std::endl;
+		return;
+	}
+	ctx.xprev = p[0];
+	ctx.yprev = p[1];
+	ctx.zprev = p[2];
+
 	if (ctx.state == CalibrationState::None || ctx.state == CalibrationState::ContinuousStandby
 		|| (ctx.state == CalibrationState::Continuous && !calibration.isValid()))
 	{

--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -46,6 +46,8 @@ struct CalibrationContext
 	double timeLastTick = 0, timeLastScan = 0;
 	double wantedUpdateInterval = 1.0;
 
+	float xprev, yprev, zprev;
+
 	float continuousCalibrationThreshold;
 	Eigen::Vector3d continuousCalibrationOffset;
 


### PR DESCRIPTION
this happens when a Quest enters out-of-bounds passthrough mode or standby for example, in which case it's almost always cleaner to keep the current calibration alive instead of calibrating towards a zero location