### PR TITLE
fall back to serial-excluded matching for HMD finding

### DIFF
--- a/OpenVR-SpaceCalibrator/VRState.cpp
+++ b/OpenVR-SpaceCalibrator/VRState.cpp
@@ -97,5 +97,12 @@ int VRState::FindDevice(const std::string& trackingSystem, const std::string& mo
 		if (device.trackingSystem == trackingSystem && device.model == model && device.serial == serial) return device.id;
 	}
 
+	// allow fallback excluding serial for HMD specifically
+	for (int i = 0; i < devices.size(); i++) {
+		const auto& device = devices[i];
+
+		if (device.trackingSystem == trackingSystem && device.model == model && device.deviceClass == vr::TrackedDeviceClass::TrackedDeviceClass_HMD) return device.id;
+	}
+
 	return -1;
 }


### PR DESCRIPTION
this allows keeping settings working between different tracking methods (e.g. switching from Virtual Desktop to Oculus Link will not break detecting the same HMD)

for some reason serial number changes between link methods...