### PR TITLE
fix startup and device assignment issues with trigger press mode

### DIFF
--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -46,10 +46,13 @@ struct CalibrationContext
 	bool validProfile = false;
 	bool clearOnLog = false;
 	bool quashTargetInContinuous = false;
-	bool requireTriggerPressToApply = false;
-	double timeLastTick = 0, timeLastScan = 0;
+	double timeLastTick = 0, timeLastScan = 0, timeLastAssign = 0;
 	double wantedUpdateInterval = 1.0;
 	float jitterThreshold = 3.0f;
+
+	bool requireTriggerPressToApply = false;
+	bool wasWaitingForTriggers = false;
+	bool hasAppliedCalibrationResult = false;
 
 	float xprev, yprev, zprev;
 


### PR DESCRIPTION
Turns out this was broken if you restarted with "Trigger Press" mode enabled, since it would never establish the initial lock. Also rescan for device changes now and then.

Diff looks best with -w (ignore whitespace).