### PR TITLE
Fixed a typo that resulted in no navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img alt="Space Calibrator" src="https://github.com/hyblocker/OpenVR-SpaceCalibrator/blob/develop/.github/logo.png?raw=true">
 </picture>
 
-This program is designed to allow you to synchronise multiple playspaces with one another in SteamVR. This fork of Space Calibrator (spacecal) also supports [continuous calibration](#continous-calibration).
+This program is designed to allow you to synchronise multiple playspaces with one another in SteamVR. This fork of Space Calibrator (spacecal) also supports [continuous calibration](#continuous-calibration).
 
 Continuous calibration is a tracking mode which automatically aligns playspaces together, using a tracker on the headset.
 


### PR DESCRIPTION
`continous` -> `continuous`

Sidenote: Idk why github also marks the last line as changed, literally edited it on the website.