### PR TITLE
This fixes an image load issue specifically on Vulkan.

### DIFF
--- a/src/overlay/renderer/renderer_vulkan.cpp
+++ b/src/overlay/renderer/renderer_vulkan.cpp
@@ -556,11 +556,12 @@ namespace spacecal {
             uintptr_t dwInternalDataIdx = (uintptr_t) -1;
             VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
 
-            unsigned char* textureData = stbi_load(szFilePath.c_str(), &width, &height, &nrChannels, STBI_rgb_alpha);
+            constexpr int k_TEXTURE_CHANNELS = STBI_rgb_alpha;
+            unsigned char* textureData = stbi_load(szFilePath.c_str(), &width, &height, &nrChannels, k_TEXTURE_CHANNELS);
             TextureData_t data = {};
 
             if (textureData) {
-                size_t image_size = width * height * nrChannels;
+                size_t image_size = width * height * k_TEXTURE_CHANNELS;
                 VkResult err;
 
                 VkTextureData_t tex_data = {};


### PR DESCRIPTION
I was trying to build this locally and run it on CachyOS and ran into a problem where the UI wouldn't load. It looks like there was an assumption that was made where `stbi_load` would fill `nrChannels` with the loaded channels. But what it actually means is the number of channels in the file itself. Since the desired channels is set to `STBI_rgb_alpha`, that makes what is actually loaded different. So a file has rgb data, but the `stbi_load` method provides rgba data.

The alternative is to load rgb, but this lets it load either rgb or rgba files. But this makes the buffer sizing more accurate.